### PR TITLE
allow specifying shell atts via config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
 					"type": "string",
 					"default": null,
 					"description": "Path for nix-shell config"
+				},
+				"nixEnvSelector.nixShellConfigAttr": {
+					"type": "string",
+					"default": null,
+					"description": "Attr for nix-shell config"
 				}
 			}
 		},

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -88,7 +88,7 @@ export const updateEditorConfig = (
         .then(_ => done(null, true), err => done(err))
     );
 
-export const activateOrShowDialog = (workspaceRoot: string) =>
+export const activateOrShowDialog = (workspaceRoot: string, nixAttr: Option<string>) =>
   fold<string, FutureInstance<Error, Option<boolean>>>(
     () => {
       return getNixConfigList(workspaceRoot)
@@ -119,7 +119,7 @@ export const activateOrShowDialog = (workspaceRoot: string) =>
         return of(
           pipe(
             nixConfigPath,
-            getShellCmd("env"),
+            getShellCmd("env", nixAttr),
             mapNullable(
               flow(
                 // HACK: sync operation using for block tread and prevent loading other

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,3 +19,8 @@ export const enum Command {
   SELECT_ENV_DIALOG = "extension.selectEnv",
   RELOAD_WINDOW = "workbench.action.reloadWindow",
 }
+
+export const enum ConfigPath {
+  SELECTED_ENV_CONFIG_KEY = "nixEnvSelector.nixShellConfig",
+  SELECTED_ATTR_CONFIG_KEY = "nixEnvSelector.nixShellConfigAttr",
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode";
 import * as Action from "./actions";
 import { ap } from "fp-ts/lib/Array";
 import { flow } from "fp-ts/lib/function";
-import { Command, Label } from "./constants";
+import { pipe } from "fp-ts/lib/pipeable";
+import { Command, Label, ConfigPath } from "./constants";
 import {
   flatten,
   fromNullable,
@@ -17,8 +18,6 @@ import { getShellCmd, toUndefined } from "./helpers";
 import Future, { FutureInstance, map, parallel } from "fluture";
 import { showStatus, showStatusWithEnv, hideStatus } from "./status-bar";
 
-const SELECTED_ENV_CONFIG_KEY = "nixEnvSelector.nixShellConfig";
-
 type ErrorHandler = (err: Error) => any;
 
 const handleError: ErrorHandler = flow(
@@ -29,7 +28,11 @@ const handleError: ErrorHandler = flow(
 const selectEnvCommandHandler = (
   workspaceRoot: string,
   config: vscode.WorkspaceConfiguration
-) => () =>
+) => () => {
+    const nixAttr = fromNullable(
+      config.get<string>(ConfigPath.SELECTED_ATTR_CONFIG_KEY)
+    );
+
     Action.getNixConfigList(workspaceRoot)
       .chain(Action.selectConfigFile(workspaceRoot))
       .map(
@@ -42,12 +45,12 @@ const selectEnvCommandHandler = (
                 1,
                 apNixConfigPath([
                   Action.updateEditorConfig(
-                    SELECTED_ENV_CONFIG_KEY,
+                    ConfigPath.SELECTED_ENV_CONFIG_KEY,
                     config,
                     workspaceRoot
                   ),
                   flow(
-                    Action.applyEnvByNixConfPath(getShellCmd("env")),
+                    Action.applyEnvByNixConfPath(getShellCmd("env", nixAttr)),
                     map(showStatus(Label.SELECTED_ENV_NEED_RELOAD, none))
                   ),
                   Action.askReload
@@ -67,6 +70,7 @@ const selectEnvCommandHandler = (
             vscode.commands.executeCommand(Command.RELOAD_WINDOW)
         )
       );
+    };
 
 export function activate(context: vscode.ExtensionContext) {
   const workspaceRoot = vscode.workspace.rootPath;
@@ -78,11 +82,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   const config = vscode.workspace.getConfiguration();
   const maybeNixEnvConfig = fromNullable(
-    config.get<string>(SELECTED_ENV_CONFIG_KEY)
+    config.get<string>(ConfigPath.SELECTED_ENV_CONFIG_KEY)
+  );
+
+  const maybeNixAttrConfig = fromNullable(
+    config.get<string>(ConfigPath.SELECTED_ATTR_CONFIG_KEY)
   );
 
   const activateOrShowDialogWithConfig = Action.activateOrShowDialog(
-    workspaceRoot
+    workspaceRoot,
+    maybeNixAttrConfig
   );
 
   context.subscriptions.push(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,15 +1,22 @@
-import { fromPredicate, mapNullable } from "fp-ts/lib/Option";
+import { isSome, none, fromPredicate, mapNullable, getOrElse, Option } from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/pipeable";
 import { NOT_MODIFIED_ENV } from "./constants";
 
-export const getShellCmd = (internalCommand: "env") => (path: string) => {
+export const getShellCmd = (internalCommand: "env", attr: Option<string>) => (path: string) => {
   const toOption = fromPredicate<string>(
     configPath => configPath !== NOT_MODIFIED_ENV
   );
+
+  const attrArg = pipe(
+    attr,
+    mapNullable(attr => `-A ${attr}`),
+    getOrElse(() => '')
+  );
+
   return pipe(
     path,
     toOption,
-    mapNullable(path => `nix-shell ${path} --run ${internalCommand}`)
+    mapNullable(path => `nix-shell ${attrArg} ${path} --run ${internalCommand}`)
   );
 };
 


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Feature | Yes |

## Problem

Lots of nix shell configs require specifying an attribute.

## Solution

Added a new config option where you can set the attr used.

**New config parameters**:

- `nixEnvSelector.nixShellConfigAttr` : optional attr