### PR TITLE
Issue #41 - Fixing the spaced path command.

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,6 +19,6 @@ export const getShellCmd = (internalCommand: "env", attr: Option<string>) => (pa
   return pipe(
     path,
     toOption,
-    mapNullable(path => `nix-shell ${attrArg} ${path} --run ${internalCommand}`),
+    mapNullable(path => `nix-shell ${attrArg} \"${path}\" --run ${internalCommand}`),
   );
 };


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Bug | No |

## Problem

Spaced paths are invalid. (Refer to #41 )

## Solution

Added quotes as suggested (changes appear to work on NixOS).