### PR TITLE
Exec nix-shell using working directory of nix-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "nix-env-selector",
-	"version": "1.0.3",
+	"version": "1.0.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "nix-env-selector",
 	"displayName": "Nix Environment Selector",
 	"description": "Allows switch environment for Visual Studio Code and extensions based on Nix config file.",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"keywords": [
 		"nix",
 		"nix-env",

--- a/src/main/ext/nix_env.cljs
+++ b/src/main/ext/nix_env.cljs
@@ -1,5 +1,6 @@
 (ns ext.nix-env
   (:require ["child_process" :refer [exec execSync]]
+            ["path" :refer [dirname]]
             [clojure.string :as s]
             [promesa.core :as p]))
 
@@ -39,13 +40,14 @@
 
 (defn get-nix-env-sync [options]
   (-> (get-shell-env-cmd options)
-      (execSync)
+      (execSync (clj->js {:cwd (dirname (:nix-config options))}))
       (.toString)
       (parse-exported-vars)))
 
 (defn get-nix-env-async [options]
   (let [env-result (p/deferred)]
     (exec (get-shell-env-cmd options)
+          (clj->js {:cwd (dirname (:nix-config options))})
           (fn [err result]
             (if (nil? err)
               (p/resolve! env-result result)


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready| Feature/Bug | No |

## Problem

The `nix-shell` is commonly run from within the directory containing the `shell.nix`/`default.nix`, implicitly setting the working directory to that which contains the `nix` file.

nix-env-selector calls `exec`/`execSync` without a working directory set. Thus the working directory is "`/`".

In the event that the `nix` file contains references to `$PWD`, not uncommon to see in a `shellHook`, the user will see different behavior from running `nix-shell` from the terminal vs the extension running it to extract the environment.

## Solution

Uses the `path#dirname` of the `:nix-config` as the `cwd` option for the `exec` and `execSync` calls.