### PR TITLE
Add logging to VS Code output channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "nix-env-selector",
 	"displayName": "Nix Environment Selector",
 	"description": "Allows switch environment for Visual Studio Code and extensions based on Nix config file.",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"keywords": [
 		"nix",
 		"nix-env",

--- a/src/main/ext/actions.cljs
+++ b/src/main/ext/actions.cljs
@@ -25,14 +25,14 @@
                           (not))) %1)
            files-res)))
 
-(defn show-propose-env-dialog []
+(defn show-propose-env-dialog [log-channel]
   (let [select-label  (-> l/lang :label :select-env)
         dismiss-label (-> l/lang :label :dismiss)
         dialog        (w/show-notification (-> l/lang :notification :env-available)
                                            [select-label dismiss-label])]
     (p/mapcat dialog
               #((cond
-                  (= select-label %1) (cmd/execute :nix-env-selector/select-env)
+                  (= select-label %1) (cmd/execute :nix-env-selector/select-env log-channel)
                   (= dismiss-label %1) (workspace/config-set! vscode-config
                                                               :workspace
                                                               :nix-env-selector/suggestion
@@ -54,21 +54,23 @@
                   (= answer support-label)
                    (open-external-url constants/donate-url)))))))
 
-(defn show-reload-dialog []
+(defn show-reload-dialog [log-channel]
   (let [reload-label   (-> l/lang :label :reload)
         reload-message (-> l/lang :notification :env-applied)
         dialog         (w/show-notification reload-message
                                             [reload-label])]
     (p/chain dialog
              #(when (= reload-label %1)
-                (cmd/execute :workbench/action.reload-window)))))
+                (cmd/execute :workbench/action.reload-window log-channel)))))
 
-(defn load-env-by-path [nix-path status]
+(defn load-env-by-path [nix-path status log-channel]
   (when nix-path
+    (w/write-log log-channel (str "Loading env in path: " nix-path))
     (status-bar/show {:text (-> l/lang :label :env-loading)}
                      status)
     (->> (env/get-nix-env-async {:nix-config     nix-path
-                                 :nix-shell-path (:nix-shell-path @config)})
+                                 :nix-shell-path (:nix-shell-path @config)}
+                                log-channel)
          (p/map (fn [env-vars]
                   (when env-vars
                     (env/set-current-env env-vars)
@@ -79,12 +81,14 @@
                                       :command :nix-env-selector/select-env} status))))
          (p/mapcat show-reload-dialog))))
 
-(defn hit-nix-environment [status]
+(defn hit-nix-environment [status log-channel]
+  (w/write-log log-channel "Running action: Hit environment")
   (fn []
     (-> (:nix-file @config)
-        (load-env-by-path status))))
+        (load-env-by-path status log-channel))))
 
-(defn select-nix-environment [status]
+(defn select-nix-environment [status log-channel]
+  (w/write-log log-channel "Running action: Select environment")
   (fn []
     (->> (get-nix-files (:workspace-root @config))
          (p/mapcat #(w/show-quick-pick {:place-holder (-> l/lang :label :select-config-placeholder)}
@@ -97,6 +101,7 @@
                   (cond
                     (= "disable" (:id nix-file-name))
                     (do
+                      (w/write-log log-channel "Selected to disable Nix environment")
                       (status-bar/hide status)
                       (workspace/config-set! vscode-config
                                              :workspace
@@ -109,10 +114,11 @@
 
                     (not-empty nix-file-name)
                     (let [nix-file (str (:workspace-root @config) "/" (:id nix-file-name))]
+                      (w/write-log log-channel (str "Selected Nix file: " nix-file))
                       (workspace/config-set! vscode-config
                                              :workspace
                                              :nix-env-selector/nix-file
                                              (unrender-workspace nix-file (:workspace-root @config)))
                       nix-file))))
-         (p/mapcat #(load-env-by-path %1 status))
+         (p/mapcat #(load-env-by-path %1 status log-channel))
          (p/error #(js/console.error %)))))

--- a/src/main/ext/constants.cljs
+++ b/src/main/ext/constants.cljs
@@ -1,3 +1,4 @@
 (ns ext.constants)
 
 (def donate-url "https://secure.wayforpay.com/button/b2fdead505bff")
+(def log-channel "Nix Env Selector")

--- a/src/main/main.cljs
+++ b/src/main/main.cljs
@@ -4,38 +4,44 @@
             [vscode.status-bar :as status]
             [vscode.context :refer [subsciribe global-state]]
             [vscode.command :as cmd]
+            [vscode.window :as w]
             [ext.actions :as act]
             [ext.nix-env :as env]
             [ext.lang :refer [lang]]
             [utils.helpers :refer [render-env-status]]))
 
 (defn activate [ctx]
-  (update-config!)
-  (let [status-bar     (status/create :left 100)]
-    (if (or (not-empty (:nix-file @config)) (not-empty (:nix-packages @config)))
-      (try
-        (-> (env/get-nix-env-sync {:nix-config     (:nix-file @config)
-                                   :packages       (:nix-packages @config)
-                                   :args           (:nix-args @config)
-                                   :nix-shell-path (:nix-shell-path @config)})
-            (env/set-current-env))
-        (->> status-bar
-             (status/show {:text    (render-env-status lang (:nix-file @config))
-                           :command :nix-env-selector/select-env}))
-        (act/show-donate-message (global-state ctx))
+  (w/create-output-channel ctx)
+  (let [log-channel (w/get-output-channel ctx)]
+    (w/write-log log-channel "Initializing config...")
+    (update-config!)
+    (w/write-log log-channel (str "Loaded config: " @config))
+    (let [status-bar     (status/create :left 100)]
+      (if (or (not-empty (:nix-file @config)) (not-empty (:nix-packages @config)))
+        (try
+          (-> (env/get-nix-env-sync {:nix-config     (:nix-file @config)
+                                    :packages       (:nix-packages @config)
+                                    :args           (:nix-args @config)
+                                    :nix-shell-path (:nix-shell-path @config)}
+                                    log-channel)
+              (env/set-current-env))
+          (->> status-bar
+              (status/show {:text    (render-env-status lang (:nix-file @config))
+                            :command :nix-env-selector/select-env}))
+          (act/show-donate-message (global-state ctx))
 
-        (catch :default e
-          (js/console.error "Applying environment error" e)))
+          (catch :default e
+            (w/write-log log-channel (str "Error applying environment: " e))))
 
-      ;; show notification that nix config available
-      ;; if workspace contains .nix file(s)
-      (p/chain (act/get-nix-files (:workspace-root @config))
-               #(when (and (:suggest-nix? @config)
-                           (> (count %1) 0))
-                  (act/show-propose-env-dialog))))
+        ;; show notification that nix config available
+        ;; if workspace contains .nix file(s)
+        (p/chain (act/get-nix-files (:workspace-root @config))
+                #(when (and (:suggest-nix? @config)
+                            (> (count %1) 0))
+                    (act/show-propose-env-dialog log-channel))))
 
-    ;; register user commands
-    (subsciribe ctx (cmd/create :nix-env-selector/select-env (act/select-nix-environment status-bar)))
-    (subsciribe ctx (cmd/create :nix-env-selector/hit-env (act/hit-nix-environment status-bar)))))
+      ;; register user commands
+      (subsciribe ctx (cmd/create :nix-env-selector/select-env (act/select-nix-environment status-bar log-channel)))
+      (subsciribe ctx (cmd/create :nix-env-selector/hit-env (act/hit-nix-environment status-bar log-channel))))))
 
 (defn deactivate [])

--- a/src/main/vscode/command.cljs
+++ b/src/main/vscode/command.cljs
@@ -1,5 +1,6 @@
 (ns vscode.command
   (:require ["vscode" :refer [commands]]
+            [vscode.window :as w]
             [utils.interop :refer [clj->js' keyword-to-path]]))
 
 (set! *warn-on-infer* false)
@@ -8,6 +9,7 @@
   (.registerCommand commands
                     (keyword-to-path cmd-id)
                     (clj->js' handler)))
-(defn execute [cmd-id]
+(defn execute [cmd-id log-channel]
+  (w/write-log log-channel (str "Executing command: " cmd-id))
   (.executeCommand commands
                    (keyword-to-path cmd-id)))

--- a/src/main/vscode/context.cljs
+++ b/src/main/vscode/context.cljs
@@ -7,3 +7,11 @@
 
 (defn global-state [ctx]
   (.-globalState ctx))
+
+(defn add-to-global-state [ctx key value]
+  (let [state (global-state ctx)]
+    (.update state key value)))
+
+(defn get-from-global-state [ctx key]
+  (let [state (global-state ctx)]
+    (.get state key)))

--- a/src/main/vscode/window.cljs
+++ b/src/main/vscode/window.cljs
@@ -1,9 +1,9 @@
 (ns vscode.window
   (:require ["vscode" :refer [window]]
+            [vscode.context :as context]
             [promesa.core :as p]
-            [utils.interop :refer [js->clj' clj->js']]))
-
-(set! *warn-on-infer* false)
+            [utils.interop :refer [js->clj' clj->js']]
+            [ext.constants :as constants]))
 
 (defn show-quick-pick [options items]
   (let [pick-result (p/deferred)]
@@ -21,3 +21,16 @@
                #(p/reject! pick-result %1)))
     (p/chain pick-result
              js->clj')))
+
+
+(defn create-output-channel [ctx]
+  (let [output-channel (.createOutputChannel window constants/log-channel)]
+    (context/add-to-global-state ctx constants/log-channel output-channel)))
+
+
+(defn get-output-channel [ctx]
+  (context/get-from-global-state ctx constants/log-channel))
+
+
+(defn write-log [^OutputChannel channel text]
+  (.appendLine channel text))


### PR DESCRIPTION
* Create a VS Code output channel during init
* Log basic operations and error messages

| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

As mentioned in #59 , it would be useful to have the extension log to the Output window, for example to help troubleshoot Nix errors.

## Solution

This creates a [VS Code Output Channel ](https://code.visualstudio.com/api/extension-capabilities/common-capabilities#output-channel) during init, to which log messages can be appended.

I add logs for these operations:

* Load config
* Select/hit env
* Run a sync/async command

Example output in the `Nix Env Selector` channel, including the error referenced in #59:

```
Initializing config...
Loaded config: {:workspace-root "/home/dan/test_nix_env", :nix-file "/home/dan/test_nix_env/env.nix", :suggest-nix? false, :nix-packages #js [], :nix-args nil, :nix-shell-path "/nix/store/hapw7q1fkjxvprnkcgw9ppczavg4daj2-nix-2.4/bin/nix-shell"}
Running command synchronously: /nix/store/hapw7q1fkjxvprnkcgw9ppczavg4daj2-nix-2.4/bin/nix-shell "/home/dan/test_nix_env/env.nix" --run export
Error applying environment: Error: Command failed: /nix/store/hapw7q1fkjxvprnkcgw9ppczavg4daj2-nix-2.4/bin/nix-shell "/home/dan/test_nix_env/env.nix" --run export
error: attribute 'npm' missing

       at /home/dan/test_nix_env/env.nix:5:9:

            4|     buildInputs = [
            5|         pkgs.npm
             |         ^
            6|     ];
(use '--show-trace' to show detailed location information)

Running action: Select environment
Running action: Hit environment
Selected to disable Nix environment
Selected Nix file: /home/dan/test_nix_env/env.nix
Loading env in path: /home/dan/test_nix_env/env.nix
Running command asynchronously: /nix/store/hapw7q1fkjxvprnkcgw9ppczavg4daj2-nix-2.4/bin/nix-shell "/home/dan/test_nix_env/env.nix" --run export
Error applying environment: error: attribute 'npm' missing

       at /home/dan/test_nix_env/env.nix:5:9:

            4|     buildInputs = [
            5|         pkgs.npm
             |         ^
            6|     ];
(use '--show-trace' to show detailed location information)
```

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Deploy Notes

No new dependencies or scripts.