### PR TITLE
activate on onLanguage event

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"*",
+		"onLanguage"
 	],
 	"main": "./dist/main.js",
 	"contributes": {


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Bug | No |

## Problem
https://github.com/arrterian/nix-env-selector/issues/80

With the March 2023 release of VS Code the nix-env-selector extension seems to be activated too late, causing other extension that depend on the loaded nix environment to fail. 
For example we install the haskell-language-server for the ghc version used in a project via nix, but the haskell language extension can't find it after instantiating the nix environment and reloading the window.

## Solution

Adding an additional activationEvent "onLanguage" in the extension manifest seems to activate the extension earlier and solves the issue (at least for the haskell extension).

This is the same approach that the [direnv-vscode](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv) extension is using, see: https://github.com/direnv/direnv-vscode/pull/463
