### PR TITLE
Fix default.nix to enable building with nix-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .vscode-test/
 *.vsix
 secrets
+result


### PR DESCRIPTION
With this change it is now possible to build the extension by just running `nix-build` inside the repository root directory. The packaged extension will be available in `result/bin` directory.

| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Tooling | No |

## Problem

Despite a `default.nix` file being provided, the extension cannot be built with `nix-build`.

## Solution

I have updated the `default.nix` file so that the extension builds through `nix-build`.

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Deploy Notes

This is purely a development quality of life change, it does not make any changes to the actual extension.