### PR TITLE
add support for multiple devShell outputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nix-env-selector",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nix-env-selector",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/vscode": "^1.97.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
           "default": false,
           "description": "Enable support for Nix flakes"
         },
+        "nixEnvSelector.flakeDevShell": {
+          "type": "string",
+          "default": null,
+          "description": "Name of the flake devShell to activate (leave empty for default)"
+        },
         "nixEnvSelector.patchTerminals": {
           "type": "boolean",
           "default": true,

--- a/src/main/config.cljs
+++ b/src/main/config.cljs
@@ -19,6 +19,7 @@
                     :nix-shell-path (-> (workspace/config-get vscode-config :nix-env-selector/nix-shell-path)
                                         (#(when %1 (render-workspace %1 workspace-root))))
                     :use-flakes     (workspace/config-get vscode-config :nix-env-selector/use-flakes)
+                    :flake-dev-shell (workspace/config-get vscode-config :nix-env-selector/flake-dev-shell)
                     :patch-terminals? (workspace/config-get vscode-config :nix-env-selector/patch-terminals)
                     :log-level      (or (workspace/config-get vscode-config :nix-env-selector/log-level) "info")})))
 

--- a/src/main/ext/actions.cljs
+++ b/src/main/ext/actions.cljs
@@ -49,13 +49,16 @@
 
 (defn load-env-by-path [nix-path status ctx]
   (when nix-path
-    (logger/info (str "Loading environment from: " nix-path))
+    (logger/info (str "Loading environment from: " nix-path
+                      (when (not-empty (:flake-dev-shell @config))
+                        (str " (devShell: " (:flake-dev-shell @config) ")"))))
     (status-bar/show {:text (-> l/lang :label :env-loading)}
                      status)
-    (->> (env/get-nix-env-async {:nix-config     nix-path
-                                 :args           (:nix-args @config)
-                                 :nix-shell-path (:nix-shell-path @config)
-                                 :use-flakes     (:use-flakes @config)})
+    (->> (env/get-nix-env-async {:nix-config      nix-path
+                                 :args            (:nix-args @config)
+                                 :nix-shell-path  (:nix-shell-path @config)
+                                 :use-flakes      (:use-flakes @config)
+                                 :flake-dev-shell (:flake-dev-shell @config)})
          (p/map (fn [env-vars]
                   (when env-vars
                     (env/set-current-env env-vars)
@@ -77,6 +80,35 @@
     (-> (:nix-file @config)
         (load-env-by-path status ctx))))
 
+(defn ^:private save-dev-shell! [shell-name]
+  (workspace/config-set! vscode-config
+                         :workspace
+                         :nix-env-selector/flake-dev-shell
+                         (or shell-name js/undefined)))
+
+(defn ^:private resolve-flake-dev-shell [nix-file]
+  (->> (env/list-flake-dev-shells {:nix-config     nix-file
+                                   :nix-shell-path (:nix-shell-path @config)})
+       (p/mapcat (fn [shell-names]
+                   (cond
+                     (empty? shell-names)
+                     (do
+                       (w/show-error-notification (-> l/lang :notification :no-dev-shells))
+                       (p/resolved nil))
+
+                     (= 1 (count shell-names))
+                     (do
+                       (logger/info (str "Single devShell found: " (first shell-names)))
+                       (p/resolved (first shell-names)))
+
+                     :else
+                     (->> (w/show-quick-pick
+                           {:place-holder (-> l/lang :label :select-dev-shell-placeholder)}
+                           (mapv (fn [name] {:id name :label name}) shell-names))
+                          (p/map (fn [picked]
+                                   (when (not-empty picked)
+                                     (:id picked))))))))))
+
 (defn select-nix-environment [status ctx]
   (logger/info "Running action: Select environment")
   (fn []
@@ -87,30 +119,45 @@
                                              (map (fn [file-name]
                                                     {:id    file-name
                                                      :label file-name}) %1))))
-         (p/map (fn [nix-file-name]
-                  (cond
-                    (= "disable" (:id nix-file-name))
-                    (do
-                      (logger/info "Disabling Nix environment")
-                      (status-bar/hide status)
-                      (vscode-ctx/clear-env-collection! ctx)
-                      (workspace/config-set! vscode-config
-                                             :workspace
-                                             :nix-env-selector/nix-file
-                                             js/undefined)
-                      (workspace/config-set! vscode-config
-                                             :workspace
-                                             :nix-env-selector/suggestion
-                                             false))
+         (p/mapcat (fn [nix-file-name]
+                     (cond
+                       (= "disable" (:id nix-file-name))
+                       (do
+                         (logger/info "Disabling Nix environment")
+                         (status-bar/hide status)
+                         (vscode-ctx/clear-env-collection! ctx)
+                         (workspace/config-set! vscode-config
+                                                :workspace
+                                                :nix-env-selector/nix-file
+                                                js/undefined)
+                         (save-dev-shell! nil)
+                         (workspace/config-set! vscode-config
+                                                :workspace
+                                                :nix-env-selector/suggestion
+                                                false)
+                         (p/resolved nil))
 
-                    (not-empty nix-file-name)
-                    (let [nix-file (str (:workspace-root @config) "/" (:id nix-file-name))]
-                      (logger/info (str "Selected Nix file: " nix-file))
-                      (workspace/config-set! vscode-config
-                                             :workspace
-                                             :nix-env-selector/nix-file
-                                             (unrender-workspace nix-file (:workspace-root @config)))
-                      nix-file))))
+                       (not-empty nix-file-name)
+                       (let [nix-file (str (:workspace-root @config) "/" (:id nix-file-name))]
+                         (logger/info (str "Selected Nix file: " nix-file))
+                         (workspace/config-set! vscode-config
+                                                :workspace
+                                                :nix-env-selector/nix-file
+                                                (unrender-workspace nix-file (:workspace-root @config)))
+                         (if (and (:use-flakes @config) (env/flake? nix-file))
+                           (->> (resolve-flake-dev-shell nix-file)
+                                (p/mapcat (fn [shell-name]
+                                            (->> (save-dev-shell! shell-name)
+                                                 (p/map (fn [_]
+                                                          (swap! config assoc :flake-dev-shell shell-name)
+                                                          nix-file))))))
+                           (->> (save-dev-shell! nil)
+                                (p/map (fn [_]
+                                         (swap! config assoc :flake-dev-shell nil)
+                                         nix-file)))))
+
+                       :else
+                       (p/resolved nil))))
          (p/mapcat #(load-env-by-path %1 status ctx))
          (p/error (fn [e]
                     (logger/error "Select environment failed" e)

--- a/src/main/ext/actions.cljs
+++ b/src/main/ext/actions.cljs
@@ -31,13 +31,13 @@
         dialog        (w/show-notification (-> l/lang :notification :env-available)
                                            [select-label dismiss-label])]
     (p/mapcat #(cond
-                  (= select-label %1)  (do (logger/info "User chose to select Nix environment")
-                                           (cmd/execute :nix-env-selector/select-env))
-                  (= dismiss-label %1) (do (logger/info "User dismissed Nix environment suggestion")
+                 (= select-label %1)  (do (logger/info "User chose to select Nix environment")
+                                          (cmd/execute :nix-env-selector/select-env))
+                 (= dismiss-label %1) (do (logger/info "User dismissed Nix environment suggestion")
                                           (workspace/config-set! vscode-config
-                                                                  :workspace
-                                                                  :nix-env-selector/suggestion
-                                                                  false)))
+                                                                 :workspace
+                                                                 :nix-env-selector/suggestion
+                                                                 false)))
               dialog)))
 
 (defn show-reload-dialog []

--- a/src/main/ext/lang.cljs
+++ b/src/main/ext/lang.cljs
@@ -4,11 +4,13 @@
   {:notification {:env-restored  "Original vscode environment will apply after reload"
                   :env-applied   "Applied. Reload your window to activate the environment"
                   :env-available "The nix environment is available in your workspace"
-                  :env-error     "Nix Env Selector: Failed to apply environment. See output channel for details."}
+                  :env-error     "Nix Env Selector: Failed to apply environment. See output channel for details."
+                  :no-dev-shells "Nix Env Selector: No devShells found in flake."}
    :label        {:env-loading               "$(loading~spin) Applying environment..."
                   :env-selected              "$(beaker) Environment: %ENV_NAME%"
                   :env-need-reload           "$(beaker) Need reload"
                   :select-config-placeholder "Select environment config"
+                  :select-dev-shell-placeholder "Select flake devShell"
                   :disabled-nix              "Disable Nix environment"
                   :reload                    "Reload"
                   :select-env                "Select"

--- a/src/main/ext/nix_env.cljs
+++ b/src/main/ext/nix_env.cljs
@@ -16,11 +16,15 @@
         false))))
 
 (defn ^:private build-nix-cmd [{:keys [options dir is-flake capture-env?]}]
-  (let [{:keys [nix-shell-path nix-config packages args]} options]
+  (let [{:keys [nix-shell-path nix-config packages args flake-dev-shell]} options
+        flake-ref (when dir
+                    (if (not-empty flake-dev-shell)
+                      (str dir "#" flake-dev-shell)
+                      dir))]
     (if is-flake
       (str (if (empty? nix-shell-path) "nix" (s/replace nix-shell-path #" " "\\ "))
            " develop"
-           (when dir (str " \"" dir "\""))
+           (when flake-ref (str " \"" flake-ref "\""))
            (when capture-env? " --command env")
            (when args (str " " args)))
       (str (if (empty? nix-shell-path) "nix-shell" (s/replace nix-shell-path #" " "\\ "))
@@ -88,6 +92,51 @@
                (logger/info (str "Parsed " (count vars) " environment variables"))
                vars))
            env-result)))
+
+(defn flake? [nix-path]
+  (and nix-path
+       (s/ends-with? nix-path "/flake.nix")))
+
+(defn ^:private extract-dev-shell-names [parsed]
+  (let [;; Newer "inventory" schema (Nix with flake-schemas):
+        ;; inventory.devShells.output.children.<system>.children.<name>
+        inventory-systems (get-in parsed ["inventory" "devShells" "output" "children"])
+        ;; Older flat schema: devShells.<system>.<name>
+        flat-systems (get parsed "devShells")
+        systems (or inventory-systems flat-systems)]
+    (->> (vals (or systems {}))
+         (filter map?)
+         (mapcat (fn [system-data]
+                   (or (keys (get system-data "children"))
+                       (when-not (contains? system-data "filtered")
+                         (keys system-data)))))
+         (distinct)
+         (vec))))
+
+(defn list-flake-dev-shells [{:keys [nix-shell-path nix-config]}]
+  (let [result (p/deferred)
+        dir (dirname nix-config)
+        nix-bin (if (empty? nix-shell-path) "nix" (s/replace nix-shell-path #" " "\\ "))
+        cmd (str nix-bin " flake show \"" dir "\" --json --no-write-lock-file")]
+    (logger/info (str "Listing flake devShells: " cmd))
+    (exec cmd
+          #js {:cwd dir :maxBuffer (* 32 1024 1024)}
+          (fn [err stdout stderr]
+            (if (nil? err)
+              (try
+                (let [parsed (js->clj (js/JSON.parse stdout))
+                      shell-names (extract-dev-shell-names parsed)]
+                  (logger/debug (str "flake show stdout length: " (count stdout)))
+                  (logger/info (str "Found devShells: " shell-names))
+                  (p/resolve! result shell-names))
+                (catch js/Error e
+                  (logger/error "Failed to parse flake show output" e)
+                  (p/reject! result e)))
+              (do
+                (logger/debug (str "stderr:\n" stderr))
+                (logger/error "nix flake show failed" (js/Error. stderr))
+                (p/reject! result err)))))
+    result))
 
 (defn set-current-env [env-vars]
   (mapv (fn [[name value]]

--- a/src/main/main.cljs
+++ b/src/main/main.cljs
@@ -31,8 +31,8 @@
             (apply-env-collection! ctx env-vars)
             (logger/info (str "Applied " (count env-vars) " variables to extension host and terminal collection")))
           (->> status-bar
-              (status/show {:text    (render-env-status lang (:nix-file @config))
-                            :command :nix-env-selector/select-env}))
+               (status/show {:text    (render-env-status lang (:nix-file @config))
+                             :command :nix-env-selector/select-env}))
           (catch :default e
             (logger/error "Failed to apply environment on startup" e)
             (w/show-error-notification (-> lang :notification :env-error))))
@@ -40,8 +40,8 @@
         ;; show notification that nix config available
         ;; if workspace contains .nix file(s)
         (p/chain (act/get-nix-files (:workspace-root @config))
-                #(when (and (:suggest-nix? @config)
-                            (> (count %1) 0))
+                 #(when (and (:suggest-nix? @config)
+                             (> (count %1) 0))
                     (act/show-propose-env-dialog))))
 
       ;; register user commands

--- a/src/main/main.cljs
+++ b/src/main/main.cljs
@@ -22,11 +22,12 @@
     (let [status-bar (status/create :left 100)]
       (if (or (not-empty (:nix-file @config)) (not-empty (:nix-packages @config)))
         (try
-          (let [env-vars (env/get-nix-env-sync {:nix-config     (:nix-file @config)
-                                                :packages       (:nix-packages @config)
-                                                :args           (:nix-args @config)
-                                                :nix-shell-path (:nix-shell-path @config)
-                                                :use-flakes     (:use-flakes @config)})]
+          (let [env-vars (env/get-nix-env-sync {:nix-config      (:nix-file @config)
+                                                :packages        (:nix-packages @config)
+                                                :args            (:nix-args @config)
+                                                :nix-shell-path  (:nix-shell-path @config)
+                                                :use-flakes      (:use-flakes @config)
+                                                :flake-dev-shell (:flake-dev-shell @config)})]
             (env/set-current-env env-vars)
             (apply-env-collection! ctx env-vars)
             (logger/info (str "Applied " (count env-vars) " variables to extension host and terminal collection")))


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No |

## Problem

* fixes #104

## Solution

Used Amp to vibe-code a patch. It looks reasonable and works after some iterations.

EDIT: I've significantly reworked this PR:
1. I reformatted the codebase with `cljfmt` ahead of time. This seemed like a reasonable choice as the commit is very small, presumably it is meant to be formatted with `cljfmt`.
2. This now supports the new `nix flake show --json` output format used by Determinate Nix with Flake Schemas enabled.

Additionally, I can give a breakdown of changes:
* changes to output log messages to include the dev shell namee
* changes to list devShells and letting the user choose if there is more than one devShell named output
* a new `nixEnvSelector.flakeDevShell` preference, used to store the selected devShell for activation on reload
* one largish chunk that looks like a format, but it's a necessary change as some paths return promises now, this is also where the user is called to select the devShell to save and use
* small plumbing changes to trip the devShell name through function calls

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New config parameters**:

- `nixEnvSelector.devshell` : name of the devshell to load on window reload

**New scripts**:

n/a

**New dependencies**:

n/a

**New dev dependencies**:

n/a