### PR TITLE
regression fix: Config not being loaded in VScode Remote Development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nix-env-selector",
-	"version": "1.1.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nix-env-selector",
-			"version": "1.1.0",
+			"version": "1.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/vscode": "^1.97.0",

--- a/src/main/config.cljs
+++ b/src/main/config.cljs
@@ -5,20 +5,29 @@
 
 (defonce config (atom {}))
 
-(defonce vscode-config  (workspace/get-configuration))
+;; See note [fresh-workspace-configuration].
+(defn get-vscode-config []
+  (workspace/get-configuration))
 
-(defn- read-rendered [key root]
+(defn- read-rendered [vscode-config key root]
   (when-let [v (workspace/config-get vscode-config key)]
     (render-workspace v root)))
 
+;; Note [fresh-workspace-configuration]:
+;; We must call `workspace.getConfiguration()` fresh each time rather than
+;; caching it at module load time (e.g. via `defonce`).
+;; In VSCode Remote Development, workspace-folder-level settings are not
+;; yet available when the module is first evaluated (before `activate()` runs).
+;; A cached object from that point would only return default values from `package.json`.
 (defn update-config! []
-  (let [workspace-root (first (workspace/get-folders))]
+  (let [vscode-config (workspace/get-configuration)
+        workspace-root (first (workspace/get-folders))]
     (reset! config {:workspace-root   workspace-root
-                    :nix-file         (read-rendered :nix-env-selector/nix-file workspace-root)
+                    :nix-file         (read-rendered vscode-config :nix-env-selector/nix-file workspace-root)
                     :suggest-nix?     (workspace/config-get vscode-config :nix-env-selector/suggestion)
                     :nix-packages     (workspace/config-get vscode-config :nix-env-selector/packages)
-                    :nix-args         (read-rendered :nix-env-selector/args workspace-root)
-                    :nix-shell-path   (read-rendered :nix-env-selector/nix-shell-path workspace-root)
+                    :nix-args         (read-rendered vscode-config :nix-env-selector/args workspace-root)
+                    :nix-shell-path   (read-rendered vscode-config :nix-env-selector/nix-shell-path workspace-root)
                     :use-flakes?      (workspace/config-get vscode-config :nix-env-selector/use-flakes)
                     :flake-shell      (not-empty (workspace/config-get vscode-config :nix-env-selector/flake-shell))
                     :patch-terminals? (workspace/config-get vscode-config :nix-env-selector/patch-terminals)

--- a/src/main/ext/actions.cljs
+++ b/src/main/ext/actions.cljs
@@ -2,7 +2,7 @@
   (:require ["fs" :refer [readdir]]
             ["path" :refer [dirname basename]]
             [clojure.string :as s]
-            [config :refer [config vscode-config]]
+            [config :refer [config get-vscode-config]]
             [vscode.window :as w]
             [vscode.command :as cmd]
             [vscode.workspace :as workspace]
@@ -42,7 +42,7 @@
                  (= select-label %1)  (do (logger/info "User chose to select Nix environment")
                                           (cmd/execute :nix-env-selector/select-env))
                  (= dismiss-label %1) (do (logger/info "User dismissed Nix environment suggestion")
-                                          (workspace/config-set! vscode-config
+                                          (workspace/config-set! (get-vscode-config)
                                                                  :workspace
                                                                  :nix-env-selector/suggestion
                                                                  false)))
@@ -68,11 +68,12 @@
   (logger/info "Disabling Nix environment")
   (status-bar/hide status)
   (vscode-ctx/clear-env-collection! ctx)
-  (swap! config assoc :nix-file nil :use-flakes? false :flake-shell nil)
-  (workspace/config-set! vscode-config :workspace :nix-env-selector/nix-file js/undefined)
-  (workspace/config-set! vscode-config :workspace :nix-env-selector/use-flakes js/undefined)
-  (workspace/config-set! vscode-config :workspace :nix-env-selector/flake-shell js/undefined)
-  (workspace/config-set! vscode-config :workspace :nix-env-selector/suggestion false))
+  (let [vscode-config (get-vscode-config)]
+    (swap! config assoc :nix-file nil :use-flakes? false :flake-shell nil)
+    (workspace/config-set! vscode-config :workspace :nix-env-selector/nix-file js/undefined)
+    (workspace/config-set! vscode-config :workspace :nix-env-selector/use-flakes js/undefined)
+    (workspace/config-set! vscode-config :workspace :nix-env-selector/flake-shell js/undefined)
+    (workspace/config-set! vscode-config :workspace :nix-env-selector/suggestion false)))
 
 (defn disable-nix-environment-command [status ctx]
   (fn []
@@ -192,13 +193,13 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- save-flake-shell! [shell-name]
-  (workspace/config-set! vscode-config
+  (workspace/config-set! (get-vscode-config)
                          :workspace
                          :nix-env-selector/flake-shell
                          (or shell-name js/undefined)))
 
 (defn- save-nix-file! [path]
-  (workspace/config-set! vscode-config
+  (workspace/config-set! (get-vscode-config)
                          :workspace
                          :nix-env-selector/nix-file
                          (if path
@@ -206,7 +207,7 @@
                            js/undefined)))
 
 (defn- save-use-flakes! [use-flakes?]
-  (workspace/config-set! vscode-config
+  (workspace/config-set! (get-vscode-config)
                          :workspace
                          :nix-env-selector/use-flakes
                          (boolean use-flakes?)))


### PR DESCRIPTION
| Status  | Type  | Config Change |
| :---: | :---: | :---: |
| Ready | Hotfix | No |

## Problem

See commit message: Config file loading vscode remote development was broken between `v1.1.0` and `v1.2.0`.

Review with good scrutiny, I am no expert at Lisp, did this with Claude, and only reviewed it for sanity and tested that it actually works.